### PR TITLE
5 rose tree

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src" "test"]
+ :deps {}
+ :aliases
+ {:test
+  {:extra-deps
+   {lambdaisland/kaocha {:mvn/version "0.0-565"}}
+   :main-opts ["-m" "kaocha.runner"]}}}

--- a/project.edn
+++ b/project.edn
@@ -1,3 +1,3 @@
 {:name "clojure/test.check port to CLR and compatible with `magic` compiler"
  :description "Adapat the port `clojure/clr.test.check` to be able to run on both JVM and CLR (using `magic`)."
- :source-paths ["test"]}
+ :source-paths ["src" "test"]}

--- a/src/clojure/test/check/rose_tree.cljc
+++ b/src/clojure/test/check/rose_tree.cljc
@@ -1,27 +1,24 @@
-;   Copyright (c) Rich Hickey, Reid Draper, and contributors.
-;   All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-;   which can be found in the file epl-v10.html at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
-
+                                        ;   Copyright (c) Rich Hickey, Reid Draper, and contributors.
+                                        ;   All rights reserved.
+                                        ;   The use and distribution terms for this software are covered by the
+                                        ;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+                                        ;   which can be found in the file epl-v10.html at the root of this distribution.
+                                        ;   By using this software in any fashion, you are agreeing to be bound by
+                                        ;   the terms of this license.
+                                        ;   You must not remove this notice, or any other, from this software.
 (ns clojure.test.check.rose-tree
   "A lazy tree data structure used for shrinking."
-  (:refer-clojure :exclude [filter remove seq])
- (:require [#?(:default clojure.core :cljs cljs.core) :as core]))                    ;;; Changed :clj to :default
+  (:refer-clojure :exclude [filter remove seq]))
 
 (deftype RoseTree [root children]
-  #?(:default  clojure.lang.Indexed                                                  ;;; Changed :clj to :default
-     :cljs IIndexed)
-  (#?(:default nth :cljs -nth) [this i]                                              ;;; Changed :clj to :default
+  clojure.lang.Indexed
+  (nth [this i]
     (cond (= i 0) root
           (= i 1) children
-          :else (throw #?(:clj  (IndexOutOfBoundsException.) :cljr (IndexOutOfRangeException.)       ;;; Added :cljr clause
-                          :cljs (js/Error. "Index out of bounds in rose tree")))))
+          :else (throw #?(:clj  (IndexOutOfBoundsException.)
+                          :cljr (IndexOutOfRangeException.)))))
 
-  (#?(:default nth :cljs -nth) [this i not-found]                                    ;;; Changed :clj to :default
+  (nth [this i not-found]
     (cond (= i 0) root
           (= i 1) children
           :else not-found)))
@@ -46,7 +43,7 @@
   "Exclude the nth value in a collection."
   [n coll]
   (lazy-seq
-   (when-let [s (core/seq coll)]
+   (when-let [s (clojure.core/seq coll)]
      (if (zero? n)
        (rest coll)
        (cons (first s)
@@ -63,7 +60,7 @@
         inner-children (children outer-root)]
     (make-rose inner-root (concat (map join outer-children)
                                   inner-children))))
-								  
+
 (defn pure
   "Puts a value `x` into a Rose tree, with no children."
   {:no-doc true}
@@ -91,7 +88,7 @@
   [pred rose]
   (make-rose (root rose)
              (map #(filter pred %)
-                  (core/filter #(pred (root %)) (children rose)))))
+                  (clojure.core/filter #(pred (root %)) (children rose)))))
 
 (defn permutations
   "Create a seq of vectors, where each rose in turn, has been replaced
@@ -122,13 +119,13 @@
   "Returns an equivalent lazy seq that is not chunked."
   [a-lazy-seq]
   (take
-   #?(:clj Double/POSITIVE_INFINITY :cljs js/Infinity :cljr Double/PositiveInfinity)       ;;; Added :cljr clause
+   #?(:clj Double/POSITIVE_INFINITY :cljr Double/PositiveInfinity)
    a-lazy-seq))
 
 (defn shrink
   {:no-doc true}
   [f roses]
-  (if (core/seq roses)
+  (if (clojure.core/seq roses)
     (make-rose (apply f (map root roses))
                (map #(shrink f %) (remove (unchunk roses))))
     (make-rose (f) [])))
@@ -168,7 +165,7 @@
   are the children from depth one _and_ two of the input
   tree."
   {:no-doc true}
-   [rose]
+  [rose]
   (make-rose (root rose)
              (let [the-children (children rose)]
                (concat (map collapse the-children)
@@ -177,7 +174,7 @@
 
 (defn- make-stack
   [children stack]
-  (if-let [s (core/seq children)]
+  (if-let [s (clojure.core/seq children)]
     (cons children stack)
     stack))
 
@@ -195,13 +192,13 @@
                    (lazy-seq
                     (if-not (seen node)
                       (cons node
-                            (if (core/seq the-children)
+                            (if (clojure.core/seq the-children)
                               (helper (first the-children) (conj seen node) (make-stack (rest the-children) stack))
-                              (when-let [s (core/seq stack)]
+                              (when-let [s (clojure.core/seq stack)]
                                 (let [f (ffirst s)
                                       r (rest (first s))]
                                   (helper f (conj seen node) (make-stack r (rest s)))))))
-                      (when-let [s (core/seq stack)]
+                      (when-let [s (clojure.core/seq stack)]
                         (let [f (ffirst s)
                               r (rest (first s))]
                           (helper f seen (make-stack r (rest s)))))))))]


### PR DESCRIPTION
close #5 

Add reader conditionals to `test.check.rose-tree`. It now compiles with both JVM and CLR

The `cljs` code was removed as well.

