### PR TITLE
Add reader conditionals to compile on both JVM and CLR

### DIFF
--- a/src/clojure/test/check/clojure_test/assertions.cljc
+++ b/src/clojure/test/check/clojure_test/assertions.cljc
@@ -7,40 +7,55 @@
 ;   You must not remove this notice, or any other, from this software.
 
 (ns clojure.test.check.clojure-test.assertions
-  #?(:cljs (:require-macros [clojure.test.check.clojure-test.assertions.cljs]))
-  (:require #?(:default [clojure.test :as t]             ;;; changed :clj to :default
-               :cljs [cljs.test :as t])))
+  (:require [clojure.test :as t]))
 
-#?(:cljr                                                 ;;; changed :clj to :cljr												
+#?(:clj
    (defn test-context-stacktrace [st]
      (drop-while
-       #(let [class-name (.FullName (.GetType ^System.Diagnostics.StackFrame %))]                           ;;; (.getClassName ^StackTraceElement %)
-          (or (.StartsWith class-name "System")                                           ;;; .startsWith  "java.lang"  -- I guess "System" as good as I can get
-              (.StartsWith  class-name "clojure.test+")                                      ;;; .startsWith "clojure.test$"
-              (.StartsWith  class-name "clojure.test.check.clojure_test+")                   ;;; .startsWith "clojure.test.check.clojure_test$"
-              (.StartsWith  class-name "clojure.test.check.clojure_test.assertions")))       ;;; .startsWith 
-       st)))
+      #(let [class-name (.getClassName ^StackTraceElement %)]
+         (or (.startsWith class-name "java.lang")
+             (.startsWith class-name "clojure.test$")
+             (.startsWith class-name "clojure.test.check.clojure_test$")
+             (.startsWith class-name "clojure.test.check.clojure_test.assertions")))
+      st))
+   :cljr
+   (defn test-context-stacktrace [st]
+     (drop-while
+      #(let [class-name (.FullName (.GetType ^System.Diagnostics.StackFrame %))]
+         (or (.StartsWith class-name "System")
+             (.StartsWith  class-name "clojure.test+")
+             (.StartsWith  class-name "clojure.test.check.clojure_test+")
+             (.StartsWith  class-name "clojure.test.check.clojure_test.assertions")))
+      st)))
 
-#?(:cljr                                                 ;;; changed :clj to :cljr		
+#?(:clj
    (defn file-and-line*
      [stacktrace]
      (if (seq stacktrace)
-       (let [^System.Diagnostics.StackFrame s (first stacktrace)]                        ;;; ^StackTraceElement
-         {:file (.GetFileName s) :line (.GetFileLineNumber s)})                              ;;; .getFileName   .getLineNumber
+       (let [^StackTraceElement s (first stacktrace)]
+         {:file (.getFileName s) :line (.getLineNumber s)})
+       {:file nil :line nil}))
+   :cljr
+   (defn file-and-line*
+     [stacktrace]
+     (if (seq stacktrace)
+       (let [^System.Diagnostics.StackFrame s (first stacktrace)]
+         {:file (.GetFileName s) :line (.GetFileLineNumber s)})
        {:file nil :line nil})))
 
 (defn check-results [m]
   (if (:pass? m)
     (t/do-report
-      {:type :pass
-       :message (dissoc m :result)})
+     {:type :pass
+      :message (dissoc m :result)})
     (t/do-report
-      (merge {:type :fail
-              :expected {:result true}
-              :actual m}
-             #?(:clj (file-and-line* (test-context-stacktrace (.getStackTrace (Thread/currentThread))))
-			    :cljr (file-and-line* (test-context-stacktrace (.GetFrames (System.Diagnostics.StackTrace.))))   ;;; Added :cljr
-                :cljs (t/file-and-line (js/Error.) 4))))))
+     (merge {:type :fail
+             :expected {:result true}
+             :actual m}
+            #?(:clj
+               (file-and-line* (test-context-stacktrace (.getStackTrace (Thread/currentThread))))
+               :cljr
+               (file-and-line* (test-context-stacktrace (.GetFrames (System.Diagnostics.StackTrace.)))))))))
 
 (defn check?
   [_ form]
@@ -48,12 +63,6 @@
      (check-results m#)))
 
 
-#?(:default                                                                                  ;;; changed :clj to :default
-   (defmethod t/assert-expr 'clojure.test.check.clojure-test/check?
-     [_ form]
-     (check? _ form))
-   :cljs
-   (when (exists? js/cljs.test$macros)
-     (defmethod js/cljs.test$macros.assert_expr 'clojure.test.check.clojure-test/check?
-       [_ msg form]
-       (clojure.test.check.clojure-test.assertions/check? msg form))))
+(defmethod t/assert-expr 'clojure.test.check.clojure-test/check?
+  [_ form]
+  (check? _ form))

--- a/test/clojure/test/check/clojure_test_test.cljc
+++ b/test/clojure/test/check/clojure_test_test.cljc
@@ -10,15 +10,7 @@
 (ns clojure.test.check.clojure-test-test
   (:require [clojure.set :as set]
             [clojure.string :as str]
-            #?@(:cljs
-                 [[cljs.test
-                  :as test
-                  :include-macros true
-                  :refer [test-var]
-                  :refer-macros [is deftest testing]]
-                 [cljs.reader :refer [read-string]]])
-            #?(:clj  [clojure.test :as test :refer :all]                                                                ;;; Added :cljr clause
-               :cljr [clojure.test :as test :refer :all])
+            [clojure.test :as test :refer :all]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
             [clojure.test.check.clojure-test :as ct :refer [defspec]]))
@@ -35,28 +27,19 @@
   (let [reports (atom [])]
     (binding [test-report test/report
               test/report (partial capturing-report reports)]
-      #?(:default                                                                                              ;;; changed :clj to :default
-         (binding [*report-counters*   (ref *initial-report-counters*)
-                   *test-out*          (System.IO.StringWriter.)                                                 ;;; java.io.StringWriter.
-                   *testing-contexts*  (list)
-                   *testing-vars*      (list)]
-           (let [out (with-out-str (test-var v))]
-             {:reports @reports
-              :report-counters @*report-counters*
-              :out out
-              :test-out (str *test-out*)}))
-         :cljs
-         (binding [test/*current-env* (test/empty-env)]
-           (let [out (with-out-str (test-var v))]
-             ;; cljs.test doesn't distinguish between *out* and *test-out*
-             {:reports @reports
-              :report-counters (:report-counters test/*current-env*)
-              :out out
-              :test-out out}))))))
+      (binding [*report-counters*   (ref *initial-report-counters*)
+                *test-out*          #?(:clj (java.io.StringWriter.) :cljr (System.IO.StringWriter.))
+                *testing-contexts*  (list)
+                *testing-vars*      (list)]
+        (let [out (with-out-str (test-var v))]
+          {:reports @reports
+           :report-counters @*report-counters*
+           :out out
+           :test-out (str *test-out*)})))))
 
 (defspec default-trial-counts
   (prop/for-all* [gen/small-integer] (constantly true)))
-  
+
 (deftest can-use-num-tests-default-value
   (let [{:keys [reports]} (capture-test-var #'default-trial-counts)
         num-tests (->> reports
@@ -103,30 +86,24 @@
   (binding [ct/*report-trials* true]
     (let [{:keys [out]} (capture-test-var #'trial-counts)]
       (is (re-matches #?(:clj (java.util.regex.Pattern/compile "(?s)\\.{5}.+")
-                         :cljs #"\.{5}[\s\S]+"  :cljr #"(?s)\.{5}.+" )           ;;; Added :cljr clause
+                         :cljr #"(?s)\.{5}.+")
                       out)))))
-					  
+
 (defspec long-running-spec 1000
-  (prop/for-all* 
-    []
-    #(do
-       #?(:clj (Thread/sleep 1)
-	      :cljr (System.Threading.Thread/Sleep 1)                                 ;;; Added :cljr clause
-          :cljs
-          (let [start (.valueOf (js/Date.))]
-            ;; let's do some busy waiting for 1 msec, so we avoid setTimeout
-            ;; which would make our test async
-            (while (= start
-                      (.valueOf (js/Date.)))
-              (apply + (range 50)))))
-       true)))
+  (prop/for-all*
+   []
+   #(do
+      #?(:clj
+         (Thread/sleep 1)
+         :cljr
+         (System.Threading.Thread/Sleep 1))
+      true)))
 
 (defn wait-for-clock-tick
   "Allow time to progress to avoid timing issues with sub-millisecond code."
   [start]
-  #?(:clj (Thread/sleep 1)  :cljr (System.Threading.Thread/Sleep 10)               ;;; Added :cljr clause
-     :cljs (while (>= start (.valueOf (js/Date.)))
-             (apply + (range 50)))))
+  #?(:clj (Thread/sleep 1)
+     :cljr (System.Threading.Thread/Sleep 10)))
 
 (deftest can-report-trials-periodically
   (binding [ct/*report-trials* ct/trial-report-periodic
@@ -149,11 +126,11 @@
         (let [initial-trial-report @last-trial-report]
           (wait-for-clock-tick initial-trial-report)
           (is (re-seq
-                #"(Passing trial \d{3} / 1000 for long-running-spec(\r)?\n)+"                             ;;; added optional \r
-                (:test-out
-                 (capture-test-var #'long-running-spec))))
+               #"(Passing trial \d{3} / 1000 for long-running-spec(\r)?\n)+"
+               (:test-out
+                (capture-test-var #'long-running-spec))))
           (is (> @last-trial-report initial-trial-report)))))))
-		  
+
 (defn- vector-elements-are-unique*
   [v]
   (== (count v) (count (distinct v))))
@@ -171,13 +148,13 @@
                                                             ;; skip any ::shrunk messages
                                                             (drop-while #(not (re-find #"^FAIL" %))))]
     (is (re-find #"^FAIL in \(this-is-supposed-to-fail\) " result-line))
-    #_#?(:clj (is (re-find #"\(clojure_test_test\.cljc:\d+\)$" result-line)))                             ;;; We do not get file info back from the stack trace
+    #?(:clj (is (re-find #"\(clojure_test_test\.cljc:\d+\)$" result-line)))
     (is (= expected-line "expected: {:result true}"))
     (let [actual (read-string (subs actual-line 10))]
       (is (set/subset? #{:result :result-data :seed :failing-size :num-tests :fail :shrunk}
                        (set (keys actual))))
       (is (= false (:result actual))))
-    (is (= more '("")))))                       ;;; (is (nil? more)) -- not sure why we get an extra blank line, and don't care.
+    (is (= more #?(:clj nil :cljr '(""))))))
 
 (deftest can-report-shrinking
   (testing "don't emit Shrinking messages by default"
@@ -190,9 +167,9 @@
       (let [{:keys [report-counters test-out]} (capture-test-var #'this-is-supposed-to-fail)]
         (is (== 1 (:fail report-counters)))
         (is (re-seq #"Shrinking this-is-supposed-to-fail starting with parameters \[\[[\s\S]+"
-                    test-out))))))	  
-	
-(deftest tcheck-118-pass-shrunk-input-on-to-clojure-test	
+                    test-out))))))
+
+(deftest tcheck-118-pass-shrunk-input-on-to-clojure-test
   (let [{trial ::ct/trial, shrinking ::ct/shrinking, shrunk ::ct/shrunk}
         (group-by :type (:reports (capture-test-var #'this-is-supposed-to-fail)))]
     ;; should have had some successful runs because the initial size
@@ -205,7 +182,7 @@
     (is (= 1 (count shrunk)))
     (let [[a b & more] (-> shrunk first ::ct/params first)]
       (is (empty? more))
-      (is (and a b (= a b)))))) 
+      (is (and a b (= a b))))))
 
 (deftest can-report-shrunk
   (testing "supress shrunk report when ct/*report-completion* is bound to false"
@@ -219,7 +196,7 @@
 
 (defspec this-throws-an-exception
   (prop/for-all [x gen/nat]
-    (throw (ex-info "this property is terrible" {}))))
+                (throw (ex-info "this property is terrible" {}))))
 
 (deftest can-re-throw-exceptions-to-clojure-test
   (let [{:keys [report-counters test-out]} (capture-test-var #'this-throws-an-exception)]
@@ -233,10 +210,10 @@
 (defn test-ns-hook
   "Run only tests defined by deftest, ignoring those defined by defspec."
   []
-  (let [tests (->> (vals (ns-interns #?(:default (find-ns 'clojure.test.check.clojure-test-test)  ;; changed :clj to :default
-                                        :cljs 'clojure.test.check.clojure-test-test)))
+  (let [tests (->> (vals (ns-interns #?(:clj (find-ns 'clojure.test.check.clojure-test-test)
+                                        :cljr (find-ns 'clojure.test.check.clojure-test-test))))
                    (filter #(let [m (meta %)]
                               (and (:test m)
                                    (not (::ct/defspec m)))))
                    (sort-by #(:line (meta %))))]
-    (test/test-vars tests)))	  
+    (test/test-vars tests)))


### PR DESCRIPTION
close #13 

`test.check.clojure-test` now compiles on both `JVM` and `CLR`.