### PR TITLE
Remove unused references in csproj

### DIFF
--- a/clr.test.check.csproj
+++ b/clr.test.check.csproj
@@ -8,8 +8,4 @@
             https://api.nuget.org/v3/index.json
         </RestoreAdditionalProjectSources>
     </PropertyGroup>
-    <ItemGroup>
-        <Reference Include="build\clojure.test.check.clj.dll" />
-        <Reference Include="build\clojure.test.check.clojure_test.clj.dll" />
-    </ItemGroup>
 </Project>

--- a/clr.test.check.nuspec
+++ b/clr.test.check.nuspec
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package>
-  <metadata>
-    <id>clr.test.check</id>
-    <version>1.1.1</version>
-    <title>clr.test.check</title>
-    <authors>skydread1</authors>
-    <description>Contains the core references for the Clojure lib test.check.</description>
-    <repository type="git" url="https://github.com/skydread1/clr.test.check" />
-    <dependencies>
-      <group targetFramework="netstandard2.0"></group>
-    </dependencies>
-  </metadata>
-  <files>
-    <file src="bin\Release\netstandard2.0\*.clj.dll" target="lib\netstandard2.0\" />
-  </files>
+    <metadata>
+        <id>clr.test.check</id>
+        <version>1.1.1</version>
+        <title>clr.test.check</title>
+        <authors>skydread1</authors>
+        <description>Contains the core references for the Clojure lib test.check.</description>
+        <repository type="git" url="https://github.com/skydread1/clr.test.check" />
+        <dependencies>
+            <group targetFramework="netstandard2.0"></group>
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="build\*.clj.dll" target="lib\netstandard2.0" />
+    </files>
 </package>

--- a/deps.edn
+++ b/deps.edn
@@ -3,5 +3,5 @@
  :aliases
  {:test
   {:extra-deps
-   {lambdaisland/kaocha {:mvn/version "0.0-565"}}
+   {lambdaisland/kaocha {:mvn/version "1.65-1029"}}
    :main-opts ["-m" "kaocha.runner"]}}}


### PR DESCRIPTION
Closes #35 
---
There is no need for references in `csproj` as the dlls were already built using Nostrand.